### PR TITLE
fix memory leak in DMA pool after unloading module

### DIFF
--- a/src/ate/common/ate_usb.c
+++ b/src/ate/common/ate_usb.c
@@ -606,7 +606,7 @@ VOID RTUSBRejectPendingPackets(
 	PQUEUE_HEADER	pQueue;
 	
 
-	for (Index = 0; Index < 4; Index++)
+	for (Index = 0; Index < NUM_OF_TX_RING; Index++)
 	{
 		NdisAcquireSpinLock(&pAd->TxSwQueueLock[Index]);
 		while (pAd->TxSwQueue[Index].Head != NULL)

--- a/src/common/cmm_mac_usb.c
+++ b/src/common/cmm_mac_usb.c
@@ -157,7 +157,7 @@ VOID RTMPResetTxRxRingMemory(
 	
 	
 	/* Free Tx frame resource*/
-	for (acidx = 0; acidx < 4; acidx++)
+	for (acidx = 0; acidx < NUM_OF_TX_RING; acidx++)
 	{
 		PHT_TX_CONTEXT pHTTXContext = &(pAd->TxContext[acidx]);
 		if (pHTTXContext && pHTTXContext->pUrb)
@@ -284,7 +284,7 @@ VOID	RTMPFreeTxRxRingMemory(
 	
 	
 	/* Free Tx frame resource*/
-	for (acidx = 0; acidx < 4; acidx++)
+	for (acidx = 0; acidx < NUM_OF_TX_RING; acidx++)
 	{
 		PHT_TX_CONTEXT pHTTXContext = &(pAd->TxContext[acidx]);
 		if (pHTTXContext)
@@ -397,7 +397,7 @@ NDIS_STATUS	NICInitTransmit(
 	DBGPRINT(RT_DEBUG_TRACE, ("--> NICInitTransmit\n"));
 
 
-	/* Init 4 set of Tx parameters*/
+	/* Init set of Tx parameters*/
 	for(acidx = 0; acidx < NUM_OF_TX_RING; acidx++)
 	{
 		/* Initialize all Transmit releated queues*/
@@ -412,7 +412,7 @@ NDIS_STATUS	NICInitTransmit(
 	do
 	{
 		
-		/* TX_RING_SIZE, 4 ACs*/
+		/* TX_RING_SIZE, ACs*/
 		
 		for(acidx=0; acidx<NUM_OF_TX_RING; acidx++)
 		{
@@ -572,7 +572,7 @@ NDIS_STATUS	RTMPAllocTxRxRingMemory(
 		/* Init send data structures and related parameters*/
 		
 		
-		/* TX_RING_SIZE, 4 ACs*/
+		/* TX_RING_SIZE, ACs*/
 		
 		for(acidx=0; acidx<NUM_OF_TX_RING; acidx++)
 		{
@@ -725,7 +725,7 @@ NDIS_STATUS RTMPInitTxRxRingMemory
 }
 
 
-#else
+#else //#ifdef RTMP_MAC_USB
 
 /*
 ========================================================================
@@ -857,7 +857,7 @@ NDIS_STATUS	NICInitTransmit(
 	DBGPRINT(RT_DEBUG_TRACE, ("--> NICInitTransmit\n"));
 	pObj = pObj;
 
-	/* Init 4 set of Tx parameters*/
+	/* Init set of Tx parameters*/
 	for(acidx = 0; acidx < NUM_OF_TX_RING; acidx++)
 	{
 		/* Initialize all Transmit releated queues*/
@@ -872,7 +872,7 @@ NDIS_STATUS	NICInitTransmit(
 	do
 	{
 		
-		/* TX_RING_SIZE, 4 ACs*/
+		/* TX_RING_SIZE, ACs*/
 		
 		for(acidx=0; acidx<NUM_OF_TX_RING; acidx++)
 		{
@@ -1042,7 +1042,7 @@ err:
 	
 	
 	/* Tx Ring*/
-	for (acidx = 0; acidx < 4; acidx++)
+	for (acidx = 0; acidx < NUM_OF_TX_RING; acidx++)
 	{
 		PHT_TX_CONTEXT pHTTxContext = &(pAd->TxContext[acidx]);
 		if (pHTTxContext)
@@ -1234,7 +1234,7 @@ VOID	RTMPFreeTxRxRingMemory(
 	
 	
 	/* Free Tx frame resource*/
-	for (acidx = 0; acidx < 4; acidx++)
+	for (acidx = 0; acidx < NUM_OF_TX_RING; acidx++)
 		{
 		PHT_TX_CONTEXT pHTTXContext = &(pAd->TxContext[acidx]);
 			if (pHTTXContext)
@@ -1276,7 +1276,7 @@ VOID	RTMPFreeTxRxRingMemory(
 	DBGPRINT(RT_DEBUG_ERROR, ("<--- RTMPFreeTxRxRingMemory\n"));
 }
 
-#endif /* RESOURCE_PRE_ALLOC */
+#endif //#ifdef RTMP_MAC_USB
 
 
 /*

--- a/src/common/rtusb_bulk.c
+++ b/src/common/rtusb_bulk.c
@@ -1491,7 +1491,7 @@ VOID	RTUSBCleanUpDataBulkOutQueue(
 	
 	DBGPRINT(RT_DEBUG_TRACE, ("--->CleanUpDataBulkOutQueue\n"));
 
-	for (Idx = 0; Idx < 4; Idx++)
+	for (Idx = 0; Idx < NUM_OF_TX_RING; Idx++)
 	{
 		pTxContext = &pAd->TxContext[Idx];
 		
@@ -1626,7 +1626,7 @@ VOID	RTUSBCancelPendingBulkOutIRP(
 /*	pLock = &pAd->BulkOutLock[MGMTPIPEIDX];*/
 /*	pPending = &pAd->BulkOutPending[MGMTPIPEIDX];*/
 
-	for (Idx = 0; Idx < 4; Idx++)
+	for (Idx = 0; Idx < NUM_OF_TX_RING; Idx++)
 	{
 		pHTTXContext = &(pAd->TxContext[Idx]);
 
@@ -1685,7 +1685,7 @@ VOID	RTUSBCancelPendingBulkOutIRP(
 	if (pPsPollContext->IRPPending == TRUE)
 		RTUSB_UNLINK_URB(pPsPollContext->pUrb);
 
-	for (Idx = 0; Idx < 4; Idx++)
+	for (Idx = 0; Idx < NUM_OF_TX_RING; Idx++)
 	{
 		NdisAcquireSpinLock(&pAd->BulkOutLock[Idx]);
 		pAd->BulkOutPending[Idx] = FALSE;


### PR DESCRIPTION
**Bug:**
When module was loaded/unloaded multiple times, following error
occurs:
rt2870: init
ERROR: 2048 KiB atomic DMA coherent pool is too small!
Please increase it with coherent_pool= kernel parameter!

**How to reproduce:**
```
for i in `seq 1 10`; do modprobe mt7601Usta && sleep 1 && rmmod
mt7601Usta && sleep 1; done
```

**Cause:**
USB_URB was allocated for TX_RING_SIZE=5
but in functions
```
    RTMPResetTxRxRingMemory()
    RTMPFreeTxRxRingMemory()
```
there is magic value 4 used instead of TX_RING_SIZE